### PR TITLE
Fix failure in `issue` API when actor is null.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -143,14 +143,17 @@ api.issue = function(actor, credential, options, callback) {
     }],
     emit: ['issue', (callback, results) => {
       var credential = results.issue;
+      var event = {
+        type: 'CredentialIssue',
+        date: new Date().toJSON(),
+        resource: [credential.id],
+        issuer: credential.issuer
+      };
+      if(actor) {
+        event.actor = actor.id;
+      }
       bedrock.events.emit(
-        'bedrock-issuer.credential.CredentialIssue', {
-          type: 'CredentialIssue',
-          date: new Date().toJSON(),
-          resource: [credential.id],
-          issuer: credential.issuer,
-          actor: actor.id
-        }, callback);
+        'bedrock-issuer.credential.CredentialIssue', event, callback);
     }]
   }, function(err, results) {
     callback(err, results.issue);

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,5 @@
+{
+  env: {
+    mocha: true
+  }
+}

--- a/test/mocha/20-api.js
+++ b/test/mocha/20-api.js
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2015-2016 Digital Bazaar, Inc. All rights reserved.
+ */
+/* globals should */
+'use strict';
+
+var async = require('async');
+var bedrock = require('bedrock');
+var brIssuer = require('bedrock-issuer');
+var eventLog = require('bedrock-event-log').log;
+var helpers = require('./helpers');
+var mockData = require('./mock.data');
+var uuid = require('uuid').v4;
+
+describe('node API', () => {
+  before('Prepare the database', function(done) {
+    helpers.prepareDatabase(mockData, done);
+  });
+  after('Remove test data', function(done) {
+    helpers.removeCollections(done);
+  });
+  describe('issue API', () => {
+    it('should issue a credential with a null actor', done => {
+      bedrock.events.on(
+        `bedrock-issuer.credential.CredentialIssue`, (e, callback) => {
+          eventLog.add(e, callback);
+        });
+      var credential = bedrock.util.clone(mockData.unsignedCredential);
+      credential.issuer = mockData.identities.organizationAlpha.identity.id;
+      credential.id = uuid();
+      async.auto({
+        issue: callback => {
+          brIssuer.issue(null, credential, callback);
+        },
+        findEvent: ['issue', callback => {
+          eventLog.find({}, callback);
+        }],
+        test: ['findEvent', (callback, results) => {
+          var r = results.findEvent;
+          r.should.be.an('array');
+          r.should.have.length(1);
+          r[0].event.should.be.an('object');
+          var event = r[0].event;
+          event.type.should.equal('CredentialIssue');
+          event.issuer.should.equal(credential.issuer);
+          should.not.exist(event.actor);
+          callback();
+        }]
+      }, done);
+    });
+  });
+});

--- a/test/mocha/mock.data.js
+++ b/test/mocha/mock.data.js
@@ -9,6 +9,18 @@ var helpers = require('./helpers');
 var mock = {};
 module.exports = mock;
 
+mock.unsignedCredential = {
+  '@context': 'https://w3id.org/credentials/v1',
+  type: ['Credential', 'BirthDateCredential'],
+  name: 'Birth Date Credential',
+  image: 'https://images.com/verified-email-badge',
+  issued: '2013-06-17T11:11:11Z',
+  claim: {
+    id: 'did:32e89321-a5f1-48ff-8ec8-a4112be1215c',
+    'schema:birthDate': '2013-06-17T11:11:11Z'
+  }
+};
+
 // TODO: Correct these paths to be more accurate
 var userName = '';
 var keyId = '';


### PR DESCRIPTION
Turns out we have a validator on the event log that `actor` must be a string.  I'm open to suggestions for something other than 'SYSTEM_PROCESS'